### PR TITLE
Small fix in a link

### DIFF
--- a/embedded-visualization/Hosts/cspe-Individual-Host-Dashboard/cspe-Individual-Host-Dashboard.json
+++ b/embedded-visualization/Hosts/cspe-Individual-Host-Dashboard/cspe-Individual-Host-Dashboard.json
@@ -23,7 +23,7 @@
       "includeVars": false,
       "tags": [],
       "targetBlank": true,
-      "title": "Jump on the VM in Turbonomic ARM UI",
+      "title": "Jump on the Host in Turbonomic ARM UI",
       "type": "link",
       "url": "../app/#/view/main/$HOST_OID/overview"
     }
@@ -2661,5 +2661,5 @@
   "timezone": "",
   "title": "Individual Host Dashboard",
   "uid": "mfPeteGnk",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
Modified the label of the jump to Turbonomic link in the Individual Host Dashboard.